### PR TITLE
Removing excessively long tests

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -851,9 +851,6 @@ class TestRequests:
             headers={str('Content-Type'): 'application/octet-stream'},
             data='\xff')  # compat.str is unicode.
 
-    def test_pyopenssl_redirect(self, httpbin_secure, httpbin_ca_bundle):
-        requests.get(httpbin_secure('status', '301'), verify=httpbin_ca_bundle)
-
     def test_invalid_ca_certificate_path(self, httpbin_secure):
         INVALID_PATH = '/garbage'
         with pytest.raises(IOError) as e:

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -153,14 +153,3 @@ class TestTestServer:
 
         # if the server thread fails to finish, the test suite will hang
         # and get killed by the jenkins timeout.
-
-    def test_server_finishes_when_no_connections(self):
-        """the server thread exits even if there are no connections"""
-        server = Server.basic_response_server()
-        with server:
-            pass
-
-        assert len(server.handler_results) == 0
-
-        # if the server thread fails to finish, the test suite will hang
-        # and get killed by the jenkins timeout.


### PR DESCRIPTION
This reduces tests that were taking an excessively long time and not impactful to the goal of this repository. This change reduces the amount of time for a full test suite run from 60+s to ~37s, with only the last test causing an extensive delay in the test output.